### PR TITLE
Update nginx to properly get the right IP

### DIFF
--- a/passenger-rails/2.3/nginx.conf.erb
+++ b/passenger-rails/2.3/nginx.conf.erb
@@ -64,9 +64,8 @@ http {
     # Set HSTS
     add_header Strict-Transport-Security "max-age=31536000" always;
 
-    #set_real_ip_from 10.0.0.0/8; # Restrict who can set real_ip_header
+    set_real_ip_from 10.0.0.0/8; # Restrict who can set real_ip_header
     real_ip_header X-Forwarded-For; # Name of header with real ip
-    real_ip_recursive on;
 
     location / {
       passenger_enabled on;


### PR DESCRIPTION
Update nginx config to use the x-forwarded-for that is passed from the ALB.