### PR TITLE
Up the number of instances to help spread requests

### DIFF
--- a/passenger-rails/2.3/nginx.conf.erb
+++ b/passenger-rails/2.3/nginx.conf.erb
@@ -33,7 +33,7 @@ http {
   passenger_ruby /usr/bin/ruby;
   passenger_app_env <%= RAILS_ENV %>;
   passenger_max_pool_size <%= ENV.fetch('PASSENGER_MAX_POOL_SIZE', '6') %>;
-  passenger_min_instances <%= ENV.fetch('PASSENGER_MIN_INSTANCES', '1') %>;
+  passenger_min_instances <%= ENV.fetch('PASSENGER_MIN_INSTANCES', '2') %>;
   <% if ENV['APP_URL'] -%>
   passenger_pre_start <% ENV['APP_URL'] -%>; # prevents the delay for the first user
   <% end -%>


### PR DESCRIPTION
We're seeing intermittent 499 errors from passenger. This should help spread that load out a bit.