### PR TITLE
Bump max number of instances to 12

### DIFF
--- a/passenger-rails/2.3/nginx.conf.erb
+++ b/passenger-rails/2.3/nginx.conf.erb
@@ -32,7 +32,7 @@ http {
   passenger_root /usr/lib/ruby/vendor_ruby/phusion_passenger/locations.ini;
   passenger_ruby /usr/bin/ruby;
   passenger_app_env <%= RAILS_ENV %>;
-  passenger_max_pool_size <%= ENV.fetch('PASSENGER_MAX_POOL_SIZE', '6') %>;
+  passenger_max_pool_size <%= ENV.fetch('PASSENGER_MAX_POOL_SIZE', '12') %>;
   passenger_min_instances <%= ENV.fetch('PASSENGER_MIN_INSTANCES', '2') %>;
   <% if ENV['APP_URL'] -%>
   passenger_pre_start <% ENV['APP_URL'] -%>; # prevents the delay for the first user


### PR DESCRIPTION
I manually bumped one instance to 9 and it was still practically idle. I think we can go straight to 12.