### PR TITLE
Redirect stageing.youearnedit.com to stage.youearnedit.com

### DIFF
--- a/passenger-rails/2.3/nginx.conf.erb
+++ b/passenger-rails/2.3/nginx.conf.erb
@@ -64,6 +64,12 @@ http {
 
   server {
     listen 80;
+    server_name staging.youearnedit.com;
+    return 301 https://stage.youearnedit.com/;
+  }
+
+  server {
+    listen 80;
     server_name default_server;
     root /usr/src/app/public;
 

--- a/passenger-rails/2.3/nginx.conf.erb
+++ b/passenger-rails/2.3/nginx.conf.erb
@@ -58,6 +58,12 @@ http {
 
   server {
     listen 80;
+    server_name stageing.youearnedit.com;
+    return 301 https://stage.youearnedit.com/;
+  }
+
+  server {
+    listen 80;
     server_name default_server;
     root /usr/src/app/public;
 


### PR DESCRIPTION
To prevent people from getting confused. This will redirect stageing.youearnedit.com (production) to stage.youearnedit.com.