### PR TITLE
OC-369 [Hotfix] Enableing compression on the assets directory

### DIFF
--- a/passenger-rails/2.3/nginx.conf.erb
+++ b/passenger-rails/2.3/nginx.conf.erb
@@ -82,7 +82,31 @@ http {
 
     # Serve assets from nginx with CORS
     location ~ ^/assets/ {
+      gzip  on;
+      gzip_http_version 1.0;
+      gzip_comp_level 2;
+      gzip_min_length 1100;
+      gzip_buffers     4 8k;
+      gzip_proxied any;
       gzip_static on;
+      gzip_types
+        # text/html is always compressed by HttpGzipModule
+        text/css
+        text/javascript
+        text/xml
+        text/plain
+        text/x-component
+        application/javascript
+        application/json
+        application/xml
+        application/rss+xml
+        font/truetype
+        font/opentype
+        application/vnd.ms-fontobject
+        image/svg+xml;
+      gzip_proxied        expired no-cache no-store private auth;
+      gzip_disable        "MSIE [1-6]\.";
+      gzip_vary           on;
       expires max;
       add_header Cache-Control public;
       add_header ETag "";


### PR DESCRIPTION
Turns on static compression completely to try to speed up downloads of text files.