### PR TITLE
Set disable_log_prefix on

### DIFF
--- a/passenger-rails/2.3/nginx.conf.erb
+++ b/passenger-rails/2.3/nginx.conf.erb
@@ -32,6 +32,7 @@ http {
   passenger_root /usr/lib/ruby/vendor_ruby/phusion_passenger/locations.ini;
   passenger_ruby /usr/bin/ruby;
   passenger_app_env <%= RAILS_ENV %>;
+  disable_log_prefix true;
   passenger_max_pool_size <%= ENV.fetch('PASSENGER_MAX_POOL_SIZE', '12') %>;
   passenger_min_instances <%= ENV.fetch('PASSENGER_MIN_INSTANCES', '2') %>;
   <% if ENV['APP_URL'] -%>

--- a/passenger-rails/2.3/nginx.conf.erb
+++ b/passenger-rails/2.3/nginx.conf.erb
@@ -32,7 +32,7 @@ http {
   passenger_root /usr/lib/ruby/vendor_ruby/phusion_passenger/locations.ini;
   passenger_ruby /usr/bin/ruby;
   passenger_app_env <%= RAILS_ENV %>;
-  disable_log_prefix true;
+  disable_log_prefix on;
   passenger_max_pool_size <%= ENV.fetch('PASSENGER_MAX_POOL_SIZE', '12') %>;
   passenger_min_instances <%= ENV.fetch('PASSENGER_MIN_INSTANCES', '2') %>;
   <% if ENV['APP_URL'] -%>

--- a/passenger-rails/2.3/nginx.conf.erb
+++ b/passenger-rails/2.3/nginx.conf.erb
@@ -32,7 +32,7 @@ http {
   passenger_root /usr/lib/ruby/vendor_ruby/phusion_passenger/locations.ini;
   passenger_ruby /usr/bin/ruby;
   passenger_app_env <%= RAILS_ENV %>;
-  disable_log_prefix on;
+  passenger_disable_log_prefix on;
   passenger_max_pool_size <%= ENV.fetch('PASSENGER_MAX_POOL_SIZE', '12') %>;
   passenger_min_instances <%= ENV.fetch('PASSENGER_MIN_INSTANCES', '2') %>;
   <% if ENV['APP_URL'] -%>


### PR DESCRIPTION
Sets disable_log_prefix to true in hopes of getting json-parseable logs.

References https://www.phusionpassenger.com/docs/references/config_reference/standalone/#--disable-log-prefix-disable_log_prefix.